### PR TITLE
Dp/refactor/result types

### DIFF
--- a/EssentialFeed/Feed API/HTTPClient.swift
+++ b/EssentialFeed/Feed API/HTTPClient.swift
@@ -7,11 +7,6 @@
 
 import Foundation
 
-public enum HTTPClientResult {
-    case success(Data, HTTPURLResponse)
-    case failure(Error)
-}
-
 /// The `HTTPClient` protocol enforces functionality to be implemented
 /// by any of the EssentialFeed application API modules. The public protocol
 /// can be implemented by external modules to initiate a networking request.
@@ -19,5 +14,7 @@ public enum HTTPClientResult {
 /// The completion handler can be invoked on any thread; therefore, clients
 /// are responsible for dispatching to appropriate threads (if needed).
 public protocol HTTPClient {
-    func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void)
+    typealias Result = Swift.Result<(Data, HTTPURLResponse), Error>
+    
+    func get(from url: URL, completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -28,7 +28,7 @@ public final class RemoteFeedLoader: FeedLoader {
             guard self != nil else { return }
             
             switch result {
-                case let .success(data, response):
+                case let .success((data, response)):
                     completion(RemoteFeedLoader.mapResultFrom(data, with: response))
                 case .failure:
                     completion(.failure(RemoteFeedLoader.Error.connectivity))

--- a/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -31,7 +31,7 @@ public final class RemoteFeedLoader: FeedLoader {
                 case let .success((data, response)):
                     completion(RemoteFeedLoader.mapResultFrom(data, with: response))
                 case .failure:
-                    completion(.failure(RemoteFeedLoader.Error.connectivity))
+                    completion(.failure(Error.connectivity))
             }
         }
     }

--- a/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -16,14 +16,12 @@ public final class RemoteFeedLoader: FeedLoader {
         case invalidData
     }
     
-    public typealias Result = LoadFeedResult
-    
     public init(client: HTTPClient, url: URL) {
         self.client = client
         self.url = url
     }
     
-    public func load(completion: @escaping (Result) -> Void) {
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         client.get(from: url) { [weak self] result in
             
             /// Prevent completion if self has been deallocated
@@ -38,7 +36,7 @@ public final class RemoteFeedLoader: FeedLoader {
         }
     }
     
-    private static func mapResultFrom(_ data: Data, with response: HTTPURLResponse) -> Result {
+    private static func mapResultFrom(_ data: Data, with response: HTTPURLResponse) -> FeedLoader.Result {
         guard let remoteItems = try? RemoteFeedMapper.mapRemoteItemsFrom(data, with: response) else {
             return .failure(Error.invalidData)
         }

--- a/EssentialFeed/Feed API/RemoteFeedMapper.swift
+++ b/EssentialFeed/Feed API/RemoteFeedMapper.swift
@@ -13,13 +13,12 @@ import Foundation
 /// Use the static `map(_:_:)` method to transform data received into an
 /// array of `[RemoteFeedItem]` and return to `RemoteFeedLoader`
 /// to handle the `[FeedImage]` mapping and result completion
-internal final class RemoteFeedMapper {
+final class RemoteFeedMapper {
     private struct Root: Decodable {
         let items: [RemoteFeedItem]
     }
     
-    internal static func mapRemoteItemsFrom(_ data: Data,
-                                        with response: HTTPURLResponse) throws -> [RemoteFeedItem] {
+    static func mapRemoteItemsFrom(_ data: Data, with response: HTTPURLResponse) throws -> [RemoteFeedItem] {
         guard isValid(response), let root = try? mapRootFrom(data) else {
             throw RemoteFeedLoader.Error.invalidData
         }

--- a/EssentialFeed/Feed API/URLSessionHTTPClient.swift
+++ b/EssentialFeed/Feed API/URLSessionHTTPClient.swift
@@ -16,12 +16,12 @@ public class URLSessionHTTPClient: HTTPClient {
     
     private struct UnexpectedRepresentationError: Error {}
     
-    public func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+    public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
         session.dataTask(with: url) { data, response, error in
             if let error = error {
                 completion(.failure(error))
             } else if let data = data, let response = response as? HTTPURLResponse {
-                completion(.success(data, response))
+                completion(.success((data, response)))
             } else {
                 completion(.failure(UnexpectedRepresentationError()))
             }

--- a/EssentialFeed/Feed API/URLSessionHTTPClient.swift
+++ b/EssentialFeed/Feed API/URLSessionHTTPClient.swift
@@ -18,13 +18,12 @@ public class URLSessionHTTPClient: HTTPClient {
     
     public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
         session.dataTask(with: url) { data, response, error in
-            if let error = error {
-                completion(.failure(error))
-            } else if let data = data, let response = response as? HTTPURLResponse {
-                completion(.success((data, response)))
-            } else {
-                completion(.failure(UnexpectedRepresentationError()))
-            }
+            completion(Result {
+                guard let data = data, let response = response as? HTTPURLResponse else {
+                    throw error ?? UnexpectedRepresentationError()
+                }
+                return (data, response)
+            })
         }.resume()
     }
 }

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -10,8 +10,11 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-    typealias DeletionCompletion = (Error?) -> Void
-    typealias InsertionCompletion = (Error?) -> Void
+    typealias DeletionResult = Result<Void, Error>
+    typealias DeletionCompletion = (DeletionResult) -> Void
+    
+    typealias InsertionResult = Result<Void, Error>
+    typealias InsertionCompletion = (InsertionResult) -> Void
     
     typealias RetrievalResult = Result<CachedFeed?, Error>
     typealias RetrievalCompletion = (RetrievalResult) -> Void

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -10,18 +10,19 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-    typealias OperationCompletion = (Error?) -> Void
+    typealias DeletionCompletion = (Error?) -> Void
+    typealias InsertionCompletion = (Error?) -> Void
     
     typealias RetrievalResult = Result<CachedFeed?, Error>
     typealias RetrievalCompletion = (RetrievalResult) -> Void
     
     /// The completion handler can be invoked on any thread; therefore, clients
     /// are responsible for dispatching to appropriate threads (if needed).
-    func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping OperationCompletion)
+    func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping InsertionCompletion)
     
     /// The completion handler can be invoked on any thread; therefore, clients
     /// are responsible for dispatching to appropriate threads (if needed).
-    func deleteCachedFeed(completion: @escaping OperationCompletion)
+    func deleteCachedFeed(completion: @escaping DeletionCompletion)
     
     /// The completion handler can be invoked on any thread; therefore, clients
     /// are responsible for dispatching to appropriate threads (if needed).

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -7,15 +7,13 @@
 
 import Foundation
 
-public enum RetrievedCachedFeedResult {
-    case empty
-    case found(feed: [LocalFeedImage], timestamp: Date)
-    case failure(Error)
-}
+public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
     typealias OperationCompletion = (Error?) -> Void
-    typealias RetrievalCompletion = (RetrievedCachedFeedResult) -> Void
+    
+    typealias RetrievalResult = Result<CachedFeed?, Error>
+    typealias RetrievalCompletion = (RetrievalResult) -> Void
     
     /// The completion handler can be invoked on any thread; therefore, clients
     /// are responsible for dispatching to appropriate threads (if needed).

--- a/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
@@ -20,10 +20,10 @@ public final class CoreDataFeedStore: FeedStore {
         perform { context in
             do {
                 try ManagedCache.replace(with: (feed, timestamp), in: context).saveIfNeeded()
-                completion(nil)
+                completion(.success(()))
             } catch {
                 context.rollback()
-                completion(error)
+                completion(.failure(error))
             }
         }
     }
@@ -32,10 +32,10 @@ public final class CoreDataFeedStore: FeedStore {
         perform { context in
             do {
                 try ManagedCache.deletePrevious(in: context).saveIfNeeded()
-                completion(nil)
+                completion(.success(()))
             } catch {
                 context.rollback()
-                completion(error)
+                completion(.failure(error))
             }
         }
     }

--- a/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
@@ -20,10 +20,10 @@ public final class CoreDataFeedStore: FeedStore {
         perform { context in
             completion(Result {
                 try ManagedCache.replace(with: (feed, timestamp), in: context).saveIfNeeded()
-            }.mapError({
+            }.mapError {
                 context.rollback()
                 return $0
-            }))
+            })
         }
     }
     
@@ -31,10 +31,10 @@ public final class CoreDataFeedStore: FeedStore {
         perform { context in
             completion(Result {
                 try ManagedCache.deletePrevious(in: context).saveIfNeeded()
-            }.mapError({
+            }.mapError {
                 context.rollback()
                 return $0
-            }))
+            })
         }
     }
     

--- a/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
@@ -16,7 +16,7 @@ public final class CoreDataFeedStore: FeedStore {
         self.moc = container.newBackgroundContext()
     }
     
-    public func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping OperationCompletion) {
+    public func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping InsertionCompletion) {
         perform { context in
             do {
                 try ManagedCache.replace(with: (feed, timestamp), in: context).saveIfNeeded()
@@ -28,7 +28,7 @@ public final class CoreDataFeedStore: FeedStore {
         }
     }
     
-    public func deleteCachedFeed(completion: @escaping OperationCompletion) {
+    public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
         perform { context in
             do {
                 try ManagedCache.deletePrevious(in: context).saveIfNeeded()

--- a/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed Cache/Infrastructure/Core Data/CoreDataFeedStore.swift
@@ -51,10 +51,10 @@ public final class CoreDataFeedStore: FeedStore {
         }
     }
     
-    private static func mapResultFrom(retrieved cache: ManagedCache?) -> RetrievedCachedFeedResult {
-        guard let cache = cache else { return .empty }
+    private static func mapResultFrom(retrieved cache: ManagedCache?) -> FeedStore.RetrievalResult {
+        guard let cache = cache else { return .success(.none) }
         
-        return .found(feed: cache.localFeed, timestamp: cache.timestamp)
+        return .success((feed: cache.localFeed, timestamp: cache.timestamp))
     }
     
     private func perform(_ action: @escaping (NSManagedObjectContext) -> Void) {

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -71,9 +71,7 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader {
-    public typealias LoadResult = LoadFeedResult
-    
-    public func load(completion: @escaping (LoadResult) -> Void) {
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         store.retrieve { [weak self] result in
             
             guard let self = self else { return }

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -30,9 +30,9 @@ public final class LocalFeedLoader: FeedLoader {
             switch result {
                 case .failure:
                     self.deleteInvalidCache(completion: completion)
-                case let .found(_, timestamp) where self.statusFor(timestamp) == .expired:
+                case let .success(.some(cache)) where self.statusFor(cache.timestamp) == .expired:
                     self.deleteInvalidCache(completion: completion)
-                case .empty, .found:
+                case .success:
                     completion(.success(.validated))
             }
         }
@@ -82,11 +82,11 @@ extension LocalFeedLoader {
             guard let self = self else { return }
             
             switch result {
-                case let .found(feed, timestamp) where self.statusFor(timestamp) == .notExpired:
-                    completion(.success(feed.modelRepresentation))
+                case let .success(.some(cache)) where self.statusFor(cache.timestamp) == .notExpired:
+                    completion(.success(cache.feed.modelRepresentation))
                 case let .failure(error):
                     completion(.failure(error))
-                case .found, .empty:
+                case .success:
                     completion(.success([]))
             }
         }

--- a/EssentialFeed/Feed Feature/FeedLoader.swift
+++ b/EssentialFeed/Feed Feature/FeedLoader.swift
@@ -7,11 +7,8 @@
 
 import Foundation
 
-public enum LoadFeedResult {
-    case success([FeedImage])
-    case failure(Error)
-}
-
 public protocol FeedLoader {
-    func load(completion: @escaping (LoadFeedResult) -> Void)
+    typealias Result = Swift.Result<[FeedImage], Error>
+    
+    func load(completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -17,7 +17,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
         
         let exp = expectation(description: "Wait for load completion")
         
-        var receivedResult: LoadFeedResult?
+        var receivedResult: FeedLoader.Result?
         feedLoader.load { result in
             receivedResult = result
             exp.fulfill()
@@ -29,7 +29,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
         assertReceivedDataMatchesTestData(receivedResult)
     }
     
-    private func assertReceivedDataMatchesTestData(_ result: LoadFeedResult?, file: StaticString = #filePath, line: UInt = #line) {
+    private func assertReceivedDataMatchesTestData(_ result: FeedLoader.Result?, file: StaticString = #filePath, line: UInt = #line) {
         let failureMessage = "Expected success result with `[FeedImage]`, but got"
         switch result {
             case .success(let imageFeed):

--- a/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -31,12 +31,7 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
         let sutToPerformLoad = makeSUT()
         let feed = mockUniqueImageFeed()
         
-        let saveExp = expectation(description: "Wait for save completion")
-        sutToPerformSave.save(feed) { saveError in
-            XCTAssertNil(saveError, "Expected to save feed successfully")
-            saveExp.fulfill()
-        }
-        wait(for: [saveExp], timeout: 1.0)
+        save(feed, to: sutToPerformSave)
         
         expect(sutToPerformLoad, toLoad: feed)
     }
@@ -97,8 +92,10 @@ extension EssentialFeedCacheIntegrationTests {
     private func save(_ feed: [FeedImage], to sut: LocalFeedLoader,
                       file: StaticString = #file, line: UInt = #line) {
         let exp = expectation(description: "Wait for save completion")
-        sut.save(feed) { error in
-            XCTAssertNil(error, "Expected to save feed successfully", file: file, line: line)
+        sut.save(feed) { result in
+            if case let .failure(error) = result {
+                XCTAssertNil(error, "Expected to save feed successfully", file: file, line: line)
+            }
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)

--- a/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -110,12 +110,12 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 extension LoadFeedFromRemoteUseCaseTests {
     
     private class HTTPClientSpy: HTTPClient {
-        var messages = [(url: URL, completion: (HTTPClientResult) -> Void)]()
+        var messages = [(url: URL, completion: (HTTPClient.Result) -> Void)]()
         var requestedURLs: [URL] {
             messages.map { $0.url }
         }
         
-        func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+        func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
             messages.append((url, completion))
         }
         
@@ -132,7 +132,7 @@ extension LoadFeedFromRemoteUseCaseTests {
                 httpVersion: nil,
                 headerFields: nil)!
             
-            messages[index].completion(.success(data, response))
+            messages[index].completion(.success((data, response)))
         }
     }
 }

--- a/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -103,13 +103,13 @@ extension URLSessionHTTPClientTests {
     }
     
     private func resultFor(data: Data?, response: URLResponse?, error: Error?,
-                           file: StaticString = #filePath, line: UInt = #line) -> HTTPClientResult {
+                           file: StaticString = #filePath, line: UInt = #line) -> HTTPClient.Result {
         
         URLProtocolStub.stub(data: data, response: response,  error: error)
         let sut = makeSUT(file: file, line: line)
         let exp = expectation(description: "Wait for completion")
         
-        var receivedResult: HTTPClientResult!
+        var receivedResult: HTTPClient.Result!
         
         sut.get(from: anyURL()) { result in
             receivedResult = result
@@ -141,7 +141,7 @@ extension URLSessionHTTPClientTests {
         let result = resultFor(data: data, response: response, error: error, file: file, line: line)
         
         switch result {
-            case .success(let receivedData, let receivedResponse):
+            case .success((let receivedData, let receivedResponse)):
                 return (receivedData, receivedResponse)
             default:
                 XCTFail("Expected success, got \(result) instead", file: file, line: line)

--- a/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
@@ -17,6 +17,6 @@ extension FailableDeleteFeedStoreSpecs where Self: XCTestCase {
     
     func assertDeleteHasNoSideEffectsOnFailedDeletion(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         deleteCache(from: sut)
-        expect(sut, toCompleteRetrievalWith: .empty, file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success(.none), file: file, line: line)
     }
 }

--- a/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -19,6 +19,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
     func assertInsertHasNoSideEffectsOnFailedInsertion(usingStore sut: FeedStore,
                                                        file: StaticString = #filePath, line: UInt = #line) {
         insert(mockNonExpiredLocalFeed(), to: sut)
-        expect(sut, toCompleteRetrievalWith: .empty, file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success(.none), file: file, line: line)
     }
 }

--- a/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FeedStoreSpecs.swift
@@ -151,8 +151,8 @@ extension FeedStoreSpecs where Self: XCTestCase {
     func insert(_ cache: (feed: [LocalFeedImage], timestamp: Date), to sut: FeedStore) -> Error? {
         let exp = expectation(description: "Wait for insertion completion")
         var insertionError: Error?
-        sut.insert(cache.feed, cache.timestamp) { error in
-            insertionError = error
+        sut.insert(cache.feed, cache.timestamp) { result in
+            if case let .failure(error) = result { insertionError = error }
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
@@ -163,8 +163,8 @@ extension FeedStoreSpecs where Self: XCTestCase {
     func deleteCache(from sut: FeedStore) -> Error? {
         let exp = expectation(description: "Wait for deletion completion")
         var deletionError: Error?
-        sut.deleteCachedFeed { error in
-            deletionError = error
+        sut.deleteCachedFeed { result in
+            if case let .failure(error) = result { deletionError = error }
             exp.fulfill()
         }
         

--- a/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed Cache/Feed Store Specs/XCTestCase+FeedStoreSpecs.swift
@@ -12,23 +12,23 @@ import EssentialFeed
 extension FeedStoreSpecs where Self: XCTestCase {
     
     func assertRetrieveDeliversEmptyOnEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
-        expect(sut, toCompleteRetrievalWith: .empty, file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success(.none), file: file, line: line)
     }
     
     func assertRetrieveHasNoSideEffectsOnEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
-        expect(sut, toCompleteRetrievalTwiceWith: .empty, file: file, line: line)
+        expect(sut, toCompleteRetrievalTwiceWith: .success(.none), file: file, line: line)
     }
     
     func assertRetrieveDeliversFoundValuesOnNonEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         let cache = mockNonExpiredLocalFeed()
         insert(cache, to: sut)
-        expect(sut, toCompleteRetrievalWith: .found(feed: cache.feed, timestamp: cache.timestamp), file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success((feed: cache.feed, timestamp: cache.timestamp)), file: file, line: line)
     }
     
     func assertRetrieveHasNoSideEffectsOnNonEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         let cache = mockNonExpiredLocalFeed()
         insert(cache, to: sut)
-        expect(sut, toCompleteRetrievalTwiceWith: .found(feed: cache.feed, timestamp: cache.timestamp), file: file, line: line)
+        expect(sut, toCompleteRetrievalTwiceWith: .success((feed: cache.feed, timestamp: cache.timestamp)), file: file, line: line)
     }
     
     func assertInsertDeliversNoErrorOnEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -49,7 +49,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         let newCache = mockNonExpiredLocalFeed()
         insert(newCache, to: sut)
         
-        expect(sut, toCompleteRetrievalWith: .found(feed: newCache.feed, timestamp: newCache.timestamp), file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success((feed: newCache.feed, timestamp: newCache.timestamp)), file: file, line: line)
         XCTAssertNotEqual(oldCache.feed, newCache.feed, "Expected mock helper to create unique feeds", file: file, line: line)
         XCTAssertNotEqual(oldCache.timestamp, newCache.timestamp, "Expected cache timestamps to differ", file: file, line: line)
     }
@@ -61,7 +61,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     
     func assertDeleteHasNoSideEffectsOnEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         deleteCache(from: sut)
-        expect(sut, toCompleteRetrievalWith: .empty, file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success(.none), file: file, line: line)
     }
     
     func assertDeleteDeliversNoErrorOnNonEmptyCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -73,7 +73,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     func assertDeleteEmptiesPreviouslyInsertedCache(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         insert(mockNonExpiredLocalFeed(), to: sut)
         deleteCache(from: sut)
-        expect(sut, toCompleteRetrievalWith: .empty, file: file, line: line)
+        expect(sut, toCompleteRetrievalWith: .success(.none), file: file, line: line)
     }
     
     func assertFeedStoreOperationSideEffectsRunSerially(usingStore sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -118,18 +118,18 @@ extension FeedStoreSpecs where Self: XCTestCase {
 // MARK: - Shared `FeedStore` Expectations & Operation Helpers
 extension FeedStoreSpecs where Self: XCTestCase {
     func expect(_ sut: FeedStore,
-                        toCompleteRetrievalWith expectedResult: RetrievedCachedFeedResult,
+                toCompleteRetrievalWith expectedResult: FeedStore.RetrievalResult,
                         file: StaticString = #filePath,
                         line: UInt = #line) {
         
         let exp = expectation(description: "Wait for retrieval completion")
         sut.retrieve { receivedResult in
             switch (expectedResult, receivedResult) {
-                case (.empty, .empty), (.failure, .failure):
+                case (.failure, .failure):
                     break
-                case let (.found(expectedFeed, expectedTimestamp), .found(receivedFeed, receivedTimestamp)):
-                    XCTAssertEqual(expectedFeed, receivedFeed, file: file, line: line)
-                    XCTAssertEqual(expectedTimestamp, receivedTimestamp, file: file, line: line)
+                case let (.success(expectedCache), .success(receivedCache)):
+                    XCTAssertEqual(expectedCache?.feed, receivedCache?.feed, file: file, line: line)
+                    XCTAssertEqual(expectedCache?.timestamp, receivedCache?.timestamp, file: file, line: line)
                 default:
                     XCTFail("Expected retrieval with \(expectedResult), got \(receivedResult) instead", file: file, line: line)
             }
@@ -140,7 +140,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     }
     
     func expect(_ sut: FeedStore,
-                        toCompleteRetrievalTwiceWith expectedResult: RetrievedCachedFeedResult,
+                        toCompleteRetrievalTwiceWith expectedResult: FeedStore.RetrievalResult,
                         file: StaticString = #filePath,
                         line: UInt = #line) {
         expect(sut, toCompleteRetrievalWith: expectedResult, file: file, line: line)

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -30,7 +30,11 @@ class FeedStoreSpy: FeedStore {
     }
     
     func completeDeletion(error: Error? = nil, at index: Int = 0) {
-        deletionCompletions[index](error)
+        if let error = error {
+            deletionCompletions[index](.failure(error))
+        } else {
+            deletionCompletions[index](.success(()))
+        }
     }
     
     func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping InsertionCompletion) {
@@ -39,7 +43,11 @@ class FeedStoreSpy: FeedStore {
     }
     
     func completeInsertion(error: Error? = nil, at index: Int = 0) {
-        insertionCompletions[index](error)
+        if let error = error {
+            insertionCompletions[index](.failure(error))
+        } else {
+            insertionCompletions[index](.success(()))
+        }
     }
     
     func retrieve(completion: @escaping RetrievalCompletion) {

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -53,9 +53,9 @@ class FeedStoreSpy: FeedStore {
     func completeRetrievalSuccessfully(with feed: [LocalFeedImage], timestamp: Date = .now, at index: Int = 0) {
         
         if feed.isEmpty {
-            return retrievalCompletions[index](.empty)
+            return retrievalCompletions[index](.success(.none))
         }
         
-        retrievalCompletions[index](.found(feed: feed, timestamp: timestamp))
+        retrievalCompletions[index](.success((feed: feed, timestamp: timestamp)))
     }
 }

--- a/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -9,7 +9,8 @@ import Foundation
 import EssentialFeed
 
 class FeedStoreSpy: FeedStore {
-    typealias OperationCompletion = FeedStore.OperationCompletion
+    typealias DeletionCompletion = FeedStore.DeletionCompletion
+    typealias InsertionCompletion = FeedStore.InsertionCompletion
     typealias RetrievalCompletion = FeedStore.RetrievalCompletion
     
     enum Message: Equatable {
@@ -19,11 +20,11 @@ class FeedStoreSpy: FeedStore {
     }
     
     private(set) var receivedMessages = [Message]()
-    private(set) var deletionCompletions = [OperationCompletion]()
-    private(set) var insertionCompletions = [OperationCompletion]()
+    private(set) var deletionCompletions = [DeletionCompletion]()
+    private(set) var insertionCompletions = [InsertionCompletion]()
     private(set) var retrievalCompletions = [RetrievalCompletion]()
     
-    func deleteCachedFeed(completion: @escaping OperationCompletion) {
+    func deleteCachedFeed(completion: @escaping DeletionCompletion) {
         receivedMessages.append(.deleteCachedFeed)
         deletionCompletions.append(completion)
     }
@@ -32,7 +33,7 @@ class FeedStoreSpy: FeedStore {
         deletionCompletions[index](error)
     }
     
-    func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping OperationCompletion) {
+    func insert(_ feed: [LocalFeedImage], _ timestamp: Date, completion: @escaping InsertionCompletion) {
         receivedMessages.append(.insert(feed, timestamp))
         insertionCompletions.append(completion)
     }

--- a/EssentialFeedTests/Feed Cache/Use Cases/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/Use Cases/CacheFeedUseCaseTests.swift
@@ -131,8 +131,8 @@ extension CacheFeedUseCaseTests {
         let exp = expectation(description: "Wait for save completion")
         
         var capturedError: NSError?
-        sut.save(mockUniqueImageFeed()) { error in
-            capturedError = error as NSError?
+        sut.save(mockUniqueImageFeed()) { result in
+            if case let .failure(error) = result { capturedError = error as NSError? }
             exp.fulfill()
         }
         

--- a/EssentialFeedTests/Feed Cache/Use Cases/LoadCachedFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/Use Cases/LoadCachedFeedUseCaseTests.swift
@@ -140,7 +140,7 @@ class LoadCachedFeedUseCaseTests: XCTestCase {
         let store = FeedStoreSpy()
         var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
         
-        var capturedResults = [LocalFeedLoader.LoadResult]()
+        var capturedResults = [FeedLoader.Result]()
         sut?.load { capturedResults.append($0) }
         
         sut = nil
@@ -163,7 +163,7 @@ extension LoadCachedFeedUseCaseTests {
     }
     
     private func expect(_ sut: LocalFeedLoader,
-                        toCompleteWith expectedResult: LocalFeedLoader.LoadResult,
+                        toCompleteWith expectedResult: FeedLoader.Result,
                         forAction action: () -> Void,
                         file: StaticString = #filePath,
                         line: UInt = #line) {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### New Features:

- Replaces user-defined result types in favor of Swift's built in `Result` type
- Refactors `CoreDataFeedStore` operations
    - Removes 'do-catch' blocks and implements the `Result` type's `init(catching:)` to handle completions
- Adds explicit result types and completion handlers for all `FeedStore` protocol operations
- Ensures test targets are updated to implement new result types and completion handlers

## Type of change

- [x] Refactor

# Target
  
- [x] Client-Side Change (Main Branch)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings